### PR TITLE
site ui improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+corpora/

--- a/app.py
+++ b/app.py
@@ -10,7 +10,10 @@ from wtforms.validators import DataRequired
 
 from .PyDictionary import web_get_records
 
-nltk.download("wordnet")
+try:
+    nltk.data.find('corpora/wordnet')
+except LookupError:
+    nltk.download("wordnet")
 
 app = Flask(__name__)
 app.config["SECRET_KEY"] = "any secret string"

--- a/app.py
+++ b/app.py
@@ -1,3 +1,6 @@
+import re
+
+import nltk
 from flask import Flask, render_template
 from flask_bootstrap import Bootstrap
 from flask_wtf import FlaskForm
@@ -7,6 +10,8 @@ from wtforms.validators import DataRequired
 
 from .PyDictionary import web_get_records
 
+nltk.download("wordnet")
+
 app = Flask(__name__)
 app.config["SECRET_KEY"] = "any secret string"
 Bootstrap(app)
@@ -15,7 +20,7 @@ csrf = CSRFProtect(app)
 
 class WordForm(FlaskForm):
     style = {
-        "style": " width:60%;font-size: 1.5vw; padding:10px;  border-radius:10px;border: 1px solid #eee; text-align: center;  transition: .3s border-color;  border: 1px solid #aaa;"
+        "style": "width:60%; font-size: 1.5vw; padding:10px; border-radius: 10px; border: 1px solid #eee; text-align: center;  transition: .3s border-color;  border: 1px solid #aaa;"
     }
     word = StringField("Word", validators=[DataRequired()], render_kw=style)
     submit = SubmitField("Find")
@@ -24,18 +29,44 @@ class WordForm(FlaskForm):
 @app.route("/", methods=["GET", "POST"])
 @app.route("/index", methods=["GET", "POST"])
 def index():
+    match_item_number = re.compile(r"\d+\.")
+
     form = WordForm()
     word = " "
     if form.validate_on_submit():
         word = form.word.data
     resp = web_get_records(word)
+
+    resp = match_item_number.sub("", resp).strip()
+
     resp = (
         resp
         if resp == "Word not found in dictionary." or word == ""
         else resp.split("\n")
     )
-    return render_template("search.html", title="PyDictionary", form=form, resp=resp)
 
+    words = []
+
+    if "not found" not in resp:
+        loop_index = -1
+        match_usage_item_letter = re.compile(r"^\w+\.")
+
+        for res in resp:
+            if "-" in  res:
+                pos = res.split("-")
+                words.append({"part_of_speech": pos[0], "value": pos[1]})
+                is_in_usage = False
+                loop_index += 1
+            elif "Definition" in res:
+                words[loop_index]["definition"] = res.replace("Definition : ", "")
+            elif match_usage_item_letter.search(res):
+                if "usage" not in words[loop_index]:
+                    words[loop_index]["usage"] = []
+
+                # words[loop_index]["usage"].append(match_usage_item_letter.sub("", res))
+                words[loop_index]["usage"].append(res)
+
+    return render_template("search.html", title="PyDictionary", form=form, resp=words)
 
 if __name__ == "__main__":
     app.run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ regex==2020.9.27
 tqdm==4.50.0
 Werkzeug==1.0.1
 WTForms==2.3.3
+Flask-Bootstrap==3.3.7.1

--- a/templates/base.html
+++ b/templates/base.html
@@ -57,9 +57,8 @@
 
     .centered2 {
       position: absolute;
-      top: 50%;
       left: 50%;
-      transform: translate(-50%, -50%);
+      transform: translate(-50%, 0%);
       text-align: center;
     }
     #submit {
@@ -70,9 +69,30 @@
       border: none;
       margin: 0;
       padding: 0;
-      background: blue;
+      background: #0b6a75;
+      border-radius: 10px;
+      cursor: pointer;
     }
 
+    .word-result-box {
+      display: flex;
+      padding: 8px 16px;
+      background: white;
+      border-radius: 8px;
+      margin-bottom: 16px;
+      flex-direction: column;
+    }
+
+    .word-result-box p {
+      margin: 6px 0px;
+      text-align: left;
+    }
+
+    .divider {
+      height: 2px;
+      width: 100%;
+      background: #ccc;
+    }
   </style>
 </head>
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -69,7 +69,6 @@
       border: none;
       margin: 0;
       padding: 0;
-<<<<<<< HEAD
       background: #0b6a75;
       border-radius: 10px;
       cursor: pointer;
@@ -82,9 +81,6 @@
       border-radius: 8px;
       margin-bottom: 16px;
       flex-direction: column;
-=======
-      background: #007acc;
->>>>>>> 5ebd328b39c2c3c63dd6dd037d63592a6eb1b8f5
     }
 
     .word-result-box p {

--- a/templates/search.html
+++ b/templates/search.html
@@ -20,9 +20,24 @@
 
 <div class="split right">
     <div class="centered2">
-        {% for para in resp %}
-        <p style="font-size:1w;">{{para}}</p>
-        {% endfor %}
+        {% if resp is iterable and resp is not string %}
+            {% for word in resp %}
+            <div class="word-result-box">
+                <p>{{ word['value'] }}</p>
+                <div class="divider"></div>
+                <p style="color: #699;">Part of Speech: {{ word['part_of_speech'] }}</p>
+                <p>Definition: {{ word['definition'] }}</p>
+                {% if word['usage'] | length > 0 %}
+                    <p>Usage: </p>
+                {% endif %}
+                {% for usage in word['usage'] %}
+                    <p>{{ usage }}</p>
+                {% endfor %}
+            </div>
+            {% endfor %}
+        {% else %}
+            <p style="font-size:1w;">Not found</p>
+        {% endif %}
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
This PR contains improvement to https://github.com/aditeyabaral/PyDictionary/issues/7

- [x] Remove the list numbers for results and instead show the results as cards
- [x] Fix for words not found in dictionary(show not found in ui)
- [x] An alternate (blue if possible) colour for the button that goes well with the background colour
- [x] A rounded edge box for the button, similar to the search box, if possible a flat or material design to match the search box

And additional improvement

- [x] add `Flask-Boostrap` dependency to `requirements.txt` since the app uses it and absense of the dep will cause "module not found error"
- [x] add `nltk.download("wordnet")` to `app.py` to download "wordnet" before using it, absense of the file will cause error when trying to search for any words.